### PR TITLE
Add show search field option

### DIFF
--- a/table_stacker/managers.py
+++ b/table_stacker/managers.py
@@ -42,6 +42,7 @@ class TableManager(models.Manager):
             obj.credits=yaml_data.get('credits', '')
             obj.is_published=yaml_data.get('is_published', False)
             obj.show_download_links=yaml_data.get("show_download_links", True)
+            obj.show_search_field=yaml_data.get("show_search_field", True)
             obj.show_in_feeds=yaml_data.get("show_in_feeds", True)
             created = False
         else:
@@ -61,6 +62,7 @@ class TableManager(models.Manager):
                 credits=yaml_data.get('credits', ''),
                 is_published=yaml_data.get('is_published', False),
                 show_download_links=yaml_data.get("show_download_links", True),
+                show_search_field=yaml_data.get("show_search_field", True),
                 show_in_feeds=yaml_data.get("show_in_feeds", True),
             )
             created = True

--- a/table_stacker/models.py
+++ b/table_stacker/models.py
@@ -31,6 +31,7 @@ class Table(models.Model):
     sources = models.TextField(blank=True)
     credits = models.TextField(blank=True)
     show_download_links = models.BooleanField(default=True)
+    show_search_field = models.BooleanField(default=True)
     # The meta
     is_published = models.BooleanField()
     show_in_feeds = models.BooleanField(default=True)

--- a/table_stacker/templates/table_stacker/table_detail.html
+++ b/table_stacker/templates/table_stacker/table_detail.html
@@ -83,7 +83,9 @@
         </div>
         
         <div id="controls">
+            {% if object.show_search_field %}
             <div id="filter">Search: <input type="text"></div>
+            {% endif %}
             <div id="pager" class="pager">
               <form {% ifequal table.total_pages 1 %}style="display:none !important;"{% endifequal %}>
                 <img src="{{ STATIC_URL }}img/first.png" class="first">

--- a/yaml/cubs-home-run-tracker.yaml
+++ b/yaml/cubs-home-run-tracker.yaml
@@ -28,6 +28,7 @@ table:
             - Career high
           options:
               max: 60
+  show_search_field: false
   is_published: true
   publication_date: 2011-08-02
   sources: Baseball Reference


### PR DESCRIPTION
This field is not always necessary, and sometimes adds clutter to a simple
table. Also, this may be useful as table-stacker transitions to a responsive
design.
